### PR TITLE
Modify samples list items view.

### DIFF
--- a/app/src/main/res/layout/samples_list_item.xml
+++ b/app/src/main/res/layout/samples_list_item.xml
@@ -5,8 +5,9 @@
     android:layout_height="wrap_content"
     android:clickable="true"
     android:focusable="true"
-    android:focusableInTouchMode="true"
+    android:focusableInTouchMode="false"
     android:padding="20dp"
-    android:textSize="20sp">
+    android:textSize="20sp"
+    android:background="?android:attr/selectableItemBackground">
 
 </TextView>


### PR DESCRIPTION
Set `focusableInTouchMode` to `false` to avoid double clicks.
Set `?android:attr/selectableItemBackground` to get feedback on clicks.