### PR TITLE
Renamed methods and classes

### DIFF
--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,6 +30,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
+    //TODO Update to 0.10.0-alpha
     implementation ('es.situm:situm-wayfinding:0.9.2-alpha@aar') {
         transitive = true
         changing = true

--- a/app/build.gradle
+++ b/app/build.gradle
@@ -30,7 +30,7 @@ dependencies {
     implementation 'androidx.appcompat:appcompat:1.4.1'
     implementation 'androidx.recyclerview:recyclerview:1.2.1'
     implementation 'androidx.constraintlayout:constraintlayout:2.1.3'
-    implementation ('es.situm:situm-wayfinding:0.11.0-alpha@aar') {
+    implementation ('es.situm:situm-wayfinding:0.14.0-alpha@aar') {
         transitive = true
         changing = true
     }

--- a/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleCustomizeUI.java
+++ b/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleCustomizeUI.java
@@ -21,7 +21,7 @@ import es.situm.sdk.model.cartography.Poi;
 import es.situm.sdk.utils.Handler;
 import es.situm.wayfinding.OnActiveBuildingListener;
 import es.situm.wayfinding.OnLibraryViewListener;
-import es.situm.wayfinding.OnPoiSelectedListener;
+import es.situm.wayfinding.OnPoiSelectionListener;
 import es.situm.wayfinding.SitumMap;
 import es.situm.wayfinding.SitumMapView;
 import es.situm.wayfinding.sample.R;
@@ -29,7 +29,7 @@ import es.situm.wayfinding.sample.R;
 public class ActivitySampleCustomizeUI extends AppCompatActivity implements
         SitumMapView.OnMapReadyCallback,
         OnActiveBuildingListener,
-        OnPoiSelectedListener, SeekBar.OnSeekBarChangeListener, OnLibraryViewListener {
+        OnPoiSelectionListener, SeekBar.OnSeekBarChangeListener, OnLibraryViewListener {
 
     private static final String TAG = ActivitySampleCustomizeUI.class.getSimpleName();
     private SitumMap mSitumMap;
@@ -48,7 +48,7 @@ public class ActivitySampleCustomizeUI extends AppCompatActivity implements
     public void onMapReady(SitumMap situmMap) {
         mSitumMap = situmMap;
         mSitumMap.setOnActiveBuildingListener(this);
-        mSitumMap.setOnPoiSelectedListener(this);
+        mSitumMap.setOnPoiSelectionListener(this);
         // Set this class to receive a call on root view created:
         mSitumMap.setOnLibraryViewListener(this);
     }
@@ -126,7 +126,7 @@ public class ActivitySampleCustomizeUI extends AppCompatActivity implements
     // Show PoI info:
     // =============================================================================================
     @Override
-    public void onPOISelected(Poi poi, Floor floor, Building building) {
+    public void onPoiSelected(Poi poi, Floor floor, Building building) {
         String text = String.format("%s at %s selected!", poi.getName(), building.getName());
         Toast.makeText(this, text, Toast.LENGTH_SHORT).show();
     }

--- a/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleListenEvents.java
+++ b/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleListenEvents.java
@@ -27,7 +27,7 @@ import es.situm.wayfinding.sample.R;
 
 public class ActivitySampleListenEvents extends AppCompatActivity implements SitumMapView.OnMapReadyCallback,
         OnUserInteractionListener, OnActiveBuildingListener, OnLoadBuildingsListener,
-        OnFloorChangeListener, OnPoiSelectionListener, OnLocationChangeListener {
+        OnFloorChangeListener, OnPoiSelectionListener, OnLocationChangeListener, OnNavigationListener {
 
     private static final String TAG = ActivitySampleListenEvents.class.getSimpleName();
 

--- a/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleListenEvents.java
+++ b/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleListenEvents.java
@@ -16,7 +16,7 @@ import es.situm.wayfinding.OnActiveBuildingListener;
 import es.situm.wayfinding.OnFloorChangeListener;
 import es.situm.wayfinding.OnLoadBuildingsListener;
 import es.situm.wayfinding.OnLocationChangeListener;
-import es.situm.wayfinding.OnPoiSelectedListener;
+import es.situm.wayfinding.OnPoiSelectionListener;
 import es.situm.wayfinding.OnUserInteractionListener;
 import es.situm.wayfinding.SitumMap;
 import es.situm.wayfinding.SitumMapView;
@@ -24,7 +24,7 @@ import es.situm.wayfinding.sample.R;
 
 public class ActivitySampleListenEvents extends AppCompatActivity implements SitumMapView.OnMapReadyCallback,
         OnUserInteractionListener, OnActiveBuildingListener, OnLoadBuildingsListener,
-        OnFloorChangeListener, OnPoiSelectedListener, OnLocationChangeListener {
+        OnFloorChangeListener, OnPoiSelectionListener, OnLocationChangeListener {
 
     private static final String TAG = ActivitySampleListenEvents.class.getSimpleName();
 
@@ -41,8 +41,8 @@ public class ActivitySampleListenEvents extends AppCompatActivity implements Sit
         // Events:
         situmMap.setOnLoadBuildingsListener(this);
         situmMap.setOnActiveBuildingListener(this);
-        situmMap.setOnPoiSelectedListener(this);
-        situmMap.setOnFloorSelectedListener(this);
+        situmMap.setOnPoiSelectionListener(this);
+        situmMap.setOnFloorChangeListener(this);
         situmMap.setUserInteractionsListener(this);
         // Stay alert of location changes:
         situmMap.setOnLocationChangeListener(this);
@@ -96,17 +96,17 @@ public class ActivitySampleListenEvents extends AppCompatActivity implements Sit
     }
 
     // =============================================================================================
-    // OnPoiSelectedListener
+    // OnPoiSelectionListener
     // =============================================================================================
 
     @Override
-    public void onPOISelected(Poi poi, Floor level, Building building) {
-        Log.d(TAG, "OnPoiSelectedListener#onPOISelected");
+    public void onPoiSelected(Poi poi, Floor level, Building building) {
+        Log.d(TAG, "OnPoiSelectionListener#onPoiSelected");
     }
 
     @Override
     public void onPoiDeselected(Building building) {
-        Log.d(TAG, "OnPoiSelectedListener#onPoiDeselected");
+        Log.d(TAG, "OnPoiSelectionListener#onPoiDeselected");
     }
 
     // =============================================================================================

--- a/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleUsingLibrary.java
+++ b/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleUsingLibrary.java
@@ -17,7 +17,7 @@ import es.situm.wayfinding.OnActiveBuildingListener;
 import es.situm.wayfinding.OnFloorChangeListener;
 import es.situm.wayfinding.OnLoadBuildingsListener;
 import es.situm.wayfinding.OnLocationChangeListener;
-import es.situm.wayfinding.OnPoiSelectedListener;
+import es.situm.wayfinding.OnPoiSelectionListener;
 import es.situm.wayfinding.OnUserInteractionListener;
 import es.situm.wayfinding.SitumMapsLibrary;
 import es.situm.wayfinding.SitumMapsListener;
@@ -25,7 +25,7 @@ import es.situm.wayfinding.sample.R;
 
 public class ActivitySampleUsingLibrary extends AppCompatActivity implements SitumMapsListener,
         OnUserInteractionListener, OnActiveBuildingListener, OnLoadBuildingsListener,
-        OnFloorChangeListener, OnPoiSelectedListener, OnLocationChangeListener {
+        OnFloorChangeListener, OnPoiSelectionListener, OnLocationChangeListener {
 
     private static final String TAG = ActivitySampleUsingLibrary.class.getSimpleName();
 
@@ -53,8 +53,8 @@ public class ActivitySampleUsingLibrary extends AppCompatActivity implements Sit
         // Events:
         mLibrary.setOnLoadBuildingsListener(this);
         mLibrary.setOnActiveBuildingListener(this);
-        mLibrary.setOnPoiSelectedListener(this);
-        mLibrary.setOnFloorSelectedListener(this);
+        mLibrary.setOnPoiSelectionListener(this);
+        mLibrary.setOnFloorChangeListener(this);
         mLibrary.setUserInteractionsListener(this);
         // Stay alert of location changes:
         mLibrary.setOnLocationChangeListener(this);
@@ -123,7 +123,7 @@ public class ActivitySampleUsingLibrary extends AppCompatActivity implements Sit
     // =============================================================================================
 
     @Override
-    public void onPOISelected(Poi poi, Floor level, Building building) {
+    public void onPoiSelected(Poi poi, Floor level, Building building) {
         Log.d(TAG, "OnPoiSelectedListener#onPOISelected");
     }
 

--- a/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleUsingLibrary.java
+++ b/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleUsingLibrary.java
@@ -119,17 +119,17 @@ public class ActivitySampleUsingLibrary extends AppCompatActivity implements Sit
     }
 
     // =============================================================================================
-    // OnPoiSelectedListener
+    // OnPoiSelectionListener
     // =============================================================================================
 
     @Override
     public void onPoiSelected(Poi poi, Floor level, Building building) {
-        Log.d(TAG, "OnPoiSelectedListener#onPOISelected");
+        Log.d(TAG, "OnPoiSelectionListener#onPoiSelected");
     }
 
     @Override
     public void onPoiDeselected(Building building) {
-        Log.d(TAG, "OnPoiSelectedListener#onPoiDeselected");
+        Log.d(TAG, "OnPoiSelectionListener#onPoiDeselected");
     }
 
     // =============================================================================================

--- a/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleUsingLibrary.java
+++ b/app/src/main/java/es/situm/wayfinding/sample/samples/ActivitySampleUsingLibrary.java
@@ -28,7 +28,7 @@ import es.situm.wayfinding.sample.R;
 
 public class ActivitySampleUsingLibrary extends AppCompatActivity implements SitumMapsListener,
         OnUserInteractionListener, OnActiveBuildingListener, OnLoadBuildingsListener,
-        OnFloorChangeListener, OnPoiSelectionListener, OnLocationChangeListener {
+        OnFloorChangeListener, OnPoiSelectionListener, OnLocationChangeListener, OnNavigationListener {
 
     private static final String TAG = ActivitySampleUsingLibrary.class.getSimpleName();
 


### PR DESCRIPTION
Renamed method setOnFloorSelectedListener(OnFloorChangeListener listener) to setOnFloorChangeListener(OnFloorChangeListener listener) in class SitumMap
Renamed method setOnPoiSelectedListener(OnPoiSelectedListener listener) to setOnPoiSelectionListener(OnPoiSelectionListener listener) in class SitumMap
Renamed method centerPoi(Poi poi) to selectPoi(Poi poi) in class SitumMap
Renamed method centerPoi(Poi poi, ActionsCallback callback) to selectPoi(Poi poi, ActionsCallback callback) in class SitumMap
Renamed class OnPoiSelectedListener to OnPoiSelectionListener
Renamed method onPOISelected to onPoiSelected in class OnPoiSelectionListener